### PR TITLE
Use monotonic clock for host sanity check timeouts

### DIFF
--- a/host_sanity.py
+++ b/host_sanity.py
@@ -42,8 +42,10 @@ def read_resp(ser, timeout: float = 5.0) -> bytes:
     ``timeout`` seconds.
     """
     buf = ""
-    deadline = time.time() + timeout
-    while time.time() < deadline:
+    # Use a monotonic clock so adjustments to the system time don't
+    # cause the timeout loop to run indefinitely.
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
         line = ser.readline().decode(errors="ignore").strip()
         if not line:
             continue
@@ -60,8 +62,10 @@ def check_echo(ser, timeout: float = 2.0) -> None:
     """Verify UART link by sending a test byte and expecting it back."""
     test = b"\xAA"
     send_cmd(ser, "t", test)
-    deadline = time.time() + timeout
-    while time.time() < deadline:
+    # ``time.monotonic`` avoids issues if the system clock changes while
+    # we're waiting for the echo response.
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
         line = ser.readline().decode(errors="ignore").strip()
         if not line:
             continue


### PR DESCRIPTION
## Summary
- prevent `host_sanity.py` from hanging when system time changes by using `time.monotonic`
- document timeout behavior for echo and response checks

## Testing
- `python3 host_sanity.py --self-test`


------
https://chatgpt.com/codex/tasks/task_e_68c574ad65888324b549ff5dafaea619