### PR TITLE
Use monotonic clock for host sanity check timeouts

### DIFF
--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -223,7 +223,9 @@
    "id": "60777ec6-e0e9-4171-be0b-512e1ef5db9e",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "!pytest -q"
+   ]
   }
  ],
  "metadata": {

--- a/host_sanity.py
+++ b/host_sanity.py
@@ -28,11 +28,13 @@ except Exception as exc:  # pragma: no cover
 
 
 def send_cmd(ser, cmd: str, data: bytes):
+    """Send a command and payload, raising ``TimeoutError`` on write issues."""
     ser.reset_input_buffer()
-    ser.write(cmd.encode())
-    ser.write(binascii.hexlify(data))
-    ser.write(b"\n")
-    ser.flush()
+    payload = cmd.encode() + binascii.hexlify(data) + b"\n"
+    try:
+        ser.write(payload)
+    except serial.SerialTimeoutException as exc:
+        raise TimeoutError(f"Timed out writing '{cmd}' command to device") from exc
 
 
 def read_resp(ser, timeout: float = 5.0) -> bytes:
@@ -42,8 +44,10 @@ def read_resp(ser, timeout: float = 5.0) -> bytes:
     ``timeout`` seconds.
     """
     buf = ""
-    deadline = time.time() + timeout
-    while time.time() < deadline:
+    # Use a monotonic clock so adjustments to the system time don't
+    # cause the timeout loop to run indefinitely.
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
         line = ser.readline().decode(errors="ignore").strip()
         if not line:
             continue
@@ -60,12 +64,13 @@ def check_echo(ser, timeout: float = 2.0) -> None:
     """Verify UART link by sending a test byte and expecting it back."""
     test = b"\xAA"
     send_cmd(ser, "t", test)
-    deadline = time.time() + timeout
-    while time.time() < deadline:
+    # ``time.monotonic`` avoids issues if the system clock changes while
+    # we're waiting for the echo response.
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
         line = ser.readline().decode(errors="ignore").strip()
         if not line:
             continue
-        print("echo debug:", line)
         if line.startswith("t") and line[1:] == test.hex():
             return
     raise TimeoutError("No echo response from device")
@@ -86,20 +91,17 @@ def run_device(port: str):
     if serial is None:
         raise SystemExit(f"pyserial required: {SERIAL_IMPORT_ERROR}")
     try:
-        ser = serial.Serial(port, 115200, timeout=0.5)
+        print(f"Connecting to {port}...", flush=True)
+        ser = serial.Serial(port, 115200, timeout=0.5, write_timeout=0.5)
     except Exception as exc:
         raise SystemExit(f"Failed to open {port}: {exc}")
     key = bytes.fromhex("000102030405060708090a0b0c0d0e0f")
     pt = bytes.fromhex("00112233445566778899aabbccddeeff")
     try:
         check_echo(ser)
-    except TimeoutError as exc:
-        ser.close()
-        raise SystemExit(str(exc))
-    send_cmd(ser, "k", key)
-    time.sleep(0.1)
-    send_cmd(ser, "p", pt)
-    try:
+        send_cmd(ser, "k", key)
+        time.sleep(0.1)
+        send_cmd(ser, "p", pt)
         ct = read_resp(ser)
     except TimeoutError as exc:
         ser.close()

--- a/tests/test_host_sanity.py
+++ b/tests/test_host_sanity.py
@@ -1,0 +1,30 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import host_sanity
+import serial
+from unittest import mock
+import pytest
+
+
+class DummySerial:
+    def reset_input_buffer(self):
+        pass
+
+    def write(self, data):
+        raise serial.SerialTimeoutException("timeout")
+
+    def readline(self):
+        return b""
+
+    def close(self):
+        pass
+
+
+def test_run_device_exits_on_unresponsive_port():
+    with mock.patch("host_sanity.serial.Serial", return_value=DummySerial()):
+        with pytest.raises(SystemExit) as cm:
+            host_sanity.run_device("/dev/ttyFAKE")
+        assert "Timed out writing" in str(cm.value)


### PR DESCRIPTION
## Summary
- prevent `host_sanity.py` from hanging when system time changes by using `time.monotonic`
- log connection attempt and set write timeout to expose serial port issues
- handle serial write timeouts and exit instead of hanging
- add regression test for unresponsive serial ports
- enable running the regression tests directly from `Untitled.ipynb`

## Testing
- `python3 host_sanity.py --self-test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c574ad65888324b549ff5dafaea619