### PR TITLE
Fix SimpleSerial UART configuration for CW-Lite target

### DIFF
--- a/PORTING_NOTES.md
+++ b/PORTING_NOTES.md
@@ -5,7 +5,8 @@ This repository contains a minimal port of the original STM32F756ZG firmware to 
 ## Major changes vs. STM32 implementation
 
 - **HAL Replacement** – all STM32 Cube/HAL calls were removed.  The firmware now uses the ChipWhisperer XMEGA HAL and the SimpleSerial v1 protocol.
-- **Clocking** – the STM32 ran from a 216 MHz PLL.  The XMEGA uses the external 32 MHz oscillator provided on the CW‑Lite board.
+- **Clocking** – the STM32 ran from a 216 MHz PLL.  The XMEGA runs from the
+  7.3728 MHz crystal on the CW‑Lite board.
 - **Trigger** – DMA/timer based triggering from the STM32 version was replaced with simple `trigger_high()` / `trigger_low()` macros driving `PORTA.0`.
 - **AES Engine** – the STM32 used a hardware AES engine with DMA.  The XMEGA build links against the software TinyAES implementation and performs blocking encryption.
 - **Memory limits** – global buffers are capped at 16‑byte blocks to fit in the ATxmega128D4’s 8 KB RAM.

--- a/xmega/hal/xmega/uart.c
+++ b/xmega/hal/xmega/uart.c
@@ -1,7 +1,11 @@
 #include "uart.h"
+#include <stdint.h>
 
 /*! Define that selects the Usart used in example. */
 #define USART USARTC0
+
+/* Default baud rate for SimpleSerial */
+#define BAUD 115200
 
 #define TIMEOUT 0
 #define BYTE_REC 1
@@ -22,11 +26,14 @@ void												init_uart0
 	/* USARTC0, 8 Data bits, No Parity, 1 Stop bit. */
 	USART_Format_Set(&USART, USART_CHSIZE_8BIT_gc, USART_PMODE_DISABLED_gc, false);
 
-        /* Set Baudrate to 115200 bps @ 32 MHz:
-         * Baudrate select = (F_CPU/(16*Baud)) - 1
-         *                 = 17
+        /* Compute baud rate divider based on F_CPU so the UART stays
+         * in sync regardless of the system clock frequency.  The
+         * hardware only needs the baud select value when the scale is
+         * zero, so we can calculate it directly here instead of using a
+         * hard-coded constant that assumed a specific clock rate.
          */
-        USART_Baudrate_Set(&USART, 17, 0);
+        uint16_t bsel = (F_CPU / (16UL * BAUD)) - 1;
+        USART_Baudrate_Set(&USART, bsel, 0);
 
 	/* Enable both RX and TX. */
 	USART_Rx_Enable(&USART);

--- a/xmega/simpleserial-aes/makefile
+++ b/xmega/simpleserial-aes/makefile
@@ -42,7 +42,7 @@ EXTRA_OPTS = NO_EXTRA_OPTS
 CFLAGS += -D$(EXTRA_OPTS)
 
 # default system clock for CW-Lite XMEGA
-F_CPU ?= 32000000
+F_CPU ?= 7372800
 
 
 ifeq ($(CRYPTO_TARGET),)


### PR DESCRIPTION
## Summary
- compute UART baud divider from F_CPU instead of hard-coding 32 MHz value
- default CW-Lite XMEGA clock to 7.3728 MHz for correct serial timing
- document CW-Lite crystal frequency in porting notes

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c82189decc83249b25d325903dbc8b